### PR TITLE
Remove CNAME to re-add custom domain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
     - name: Build
       run: |
         npm run build
-        cp CNAME dist/
         cp dist/index.html dist/404.html
     - name: Deploy
       if: github.ref == 'refs/heads/master'

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-codesoom.com


### PR DESCRIPTION
Remove CNAME to remove and re-add custom domain because of trouble with not
working with `www` subdomain.

See also
  - https://help.github.com/en/github/working-with-github-pages/troubleshooting-custom-domains-and-github-pages#https-errors