### PR TITLE
Rename CNAME to www.codesoom.com

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-codesoom.com
+www.codesoom.com


### PR DESCRIPTION
Rename CNAME to www.codesoom.com from codesoom.com because of trouble
with https.

See also
  - https://medium.com/@monarchwadia/github-pages-setting-up-www-subdomain-with-ssl-https-aca9eca371d6